### PR TITLE
Implement a more elegant solution for clearing flash messages on navigation

### DIFF
--- a/src/components/FlashMessage.jsx
+++ b/src/components/FlashMessage.jsx
@@ -10,9 +10,9 @@ import { colors, sizes, spacing, fontSizes } from '../variables';
 import alertActions from '../store/actions/alerts';
 
 const StyledWrapper = styled.div`
-  background-color: ${(props) => lighten(0.45, colors[props.type])};
+  background-color: ${(props) => lighten(0.45, colors[props.category])};
   border-bottom: ${sizes.border}px solid
-    ${(props) => lighten(0.2, colors[props.type])};
+    ${(props) => lighten(0.2, colors[props.category])};
   position: relative;
   z-index: 1;
 `;
@@ -25,7 +25,7 @@ const StyledDiv = styled(PageWrapper)`
   grid-column-gap: ${spacing[4]}px;
   align-items: center;
   width: 100%;
-  color: ${(props) => colors[props.type]};
+  color: ${(props) => colors[props.category]};
   font-size: ${fontSizes.sans[2]}px;
 
   p {
@@ -33,21 +33,21 @@ const StyledDiv = styled(PageWrapper)`
   }
 
   ${IconButton} {
-    color: ${(props) => colors[props.type]};
+    color: ${(props) => colors[props.category]};
 
     &:hover {
       color: white;
-      background-color: ${(props) => colors[props.type]};
+      background-color: ${(props) => colors[props.category]};
     }
   }
 `;
 
 const FlashMessage = (props) => {
-  const { text, type, id, onClick } = props;
+  const { text, category, id, onClick } = props;
   if (!text) return null;
   return (
-    <StyledWrapper type={type}>
-      <StyledDiv type={type}>
+    <StyledWrapper category={category}>
+      <StyledDiv category={category}>
         <p>{text}</p>
         <IconButton
           type="button"

--- a/src/components/FlashMessages.jsx
+++ b/src/components/FlashMessages.jsx
@@ -7,14 +7,16 @@ const FlashMessages = (props) => {
   const { alerts } = props;
   const messages = [];
   alerts.forEach((alert) => {
-    messages.push(
-      <FlashMessage
-        key={alert.id}
-        id={alert.id}
-        text={alert.message}
-        type={alert.type}
-      />
-    );
+    if (alert.pending !== true) {
+      messages.push(
+        <FlashMessage
+          key={alert.id}
+          id={alert.id}
+          text={alert.message}
+          category={alert.category}
+        />
+      );
+    }
   });
   return <div>{messages}</div>;
 };

--- a/src/components/JoinGame.jsx
+++ b/src/components/JoinGame.jsx
@@ -61,8 +61,9 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onJoin: () =>
       dispatch(
-        alertActions.success({
-          message: 'Joined game!',
+        alertActions.add({
+          message: 'Joined game.',
+          category: 'success',
         })
       ),
   };

--- a/src/store/actions/actionTypes.jsx
+++ b/src/store/actions/actionTypes.jsx
@@ -11,8 +11,9 @@ export const authConstants = {
 };
 
 export const alertConstants = {
-  SUCCESS: 'ALERT_SUCCESS',
-  ERROR: 'ALERT_ERROR',
+  ADD: 'ALERT_ADD',
   CLEAR: 'ALERT_CLEAR',
+  CLEAR_ACTIVE: 'ALERT_CLEAR_ACTIVE',
   CLEAR_ALL: 'ALERT_CLEAR_ALL',
+  PROMOTE_PENDING: 'ALERT_PROMOTE_PENDING',
 };

--- a/src/store/actions/alerts.jsx
+++ b/src/store/actions/alerts.jsx
@@ -1,18 +1,12 @@
 import { alertConstants } from './actionTypes';
 
-function success(alert) {
-  const { message } = alert;
+function add(alert) {
+  const { message, category, pending } = alert;
   return {
-    type: alertConstants.SUCCESS,
+    type: alertConstants.ADD,
     message,
-  };
-}
-
-function error(alert) {
-  const { message } = alert;
-  return {
-    type: alertConstants.ERROR,
-    message,
+    category,
+    pending,
   };
 }
 
@@ -23,17 +17,30 @@ function clear(id) {
   };
 }
 
+function clearActive() {
+  return {
+    type: alertConstants.CLEAR_ACTIVE,
+  };
+}
+
 function clearAll() {
   return {
     type: alertConstants.CLEAR_ALL,
   };
 }
 
+function promotePending() {
+  return {
+    type: alertConstants.PROMOTE_PENDING,
+  };
+}
+
 const alertActions = {
-  success,
-  error,
+  add,
   clear,
+  clearActive,
   clearAll,
+  promotePending,
 };
 
 export default alertActions;

--- a/src/store/actions/auth.jsx
+++ b/src/store/actions/auth.jsx
@@ -11,18 +11,23 @@ function login(username, password) {
       (response) => {
         const { user, token } = response;
         dispatch({ type: authConstants.LOGIN_SUCCESS, user, token });
+        dispatch(
+          alertActions.add({
+            message: 'Logged in. Welcome!',
+            category: 'success',
+            pending: true,
+          })
+        );
         dispatch(push('/'));
-        setTimeout(() => {
-          dispatch(
-            alertActions.success({
-              message: 'Logged in successfully. Welcome!',
-            })
-          );
-        });
       },
       (error) => {
         dispatch({ type: authConstants.LOGIN_FAILURE });
-        dispatch(alertActions.error(error));
+        dispatch(
+          alertActions.add({
+            message: error.message,
+            category: 'error',
+          })
+        );
       }
     );
   };
@@ -35,18 +40,23 @@ function register(username, email, password) {
     authService.register(username, email, password).then(
       () => {
         dispatch({ type: authConstants.REGISTER_SUCCESS });
+        dispatch(
+          alertActions.add({
+            message: 'Created a new account. Please log in.',
+            category: 'success',
+            pending: true,
+          })
+        );
         dispatch(push('/login'));
-        setTimeout(() => {
-          dispatch(
-            alertActions.success({
-              message: 'Registration successful! Please log in.',
-            })
-          );
-        });
       },
       (error) => {
         dispatch({ type: authConstants.REGISTER_FAILURE });
-        dispatch(alertActions.error(error));
+        dispatch(
+          alertActions.add({
+            message: error.message,
+            category: 'error',
+          })
+        );
       }
     );
   };
@@ -56,10 +66,14 @@ function logout() {
   return (dispatch) => {
     authService.logout();
     dispatch({ type: authConstants.LOGOUT });
+    dispatch(
+      alertActions.add({
+        message: 'Logged out.',
+        category: 'success',
+        pending: true,
+      })
+    );
     dispatch(push('/login'));
-    setTimeout(() => {
-      dispatch(alertActions.success({ message: 'Logged out successfully.' }));
-    });
   };
 }
 

--- a/src/store/reducers/alerts.jsx
+++ b/src/store/reducers/alerts.jsx
@@ -3,30 +3,36 @@ import { alertConstants } from '../actions/actionTypes';
 function alerts(state = [], action) {
   const nextId = state.length !== 0 ? state[state.length - 1].id + 1 : 1;
   switch (action.type) {
-    case alertConstants.SUCCESS:
+    case alertConstants.ADD:
+      console.log(state);
       return [
         ...state,
         {
           id: nextId,
-          type: 'success',
+          category: action.category,
           message: action.message,
-        },
-      ];
-    case alertConstants.ERROR:
-      return [
-        ...state,
-        {
-          id: nextId,
-          type: 'danger',
-          message: action.message,
+          pending: action.pending === true,
         },
       ];
     case alertConstants.CLEAR:
       return state.filter((obj) => {
         return obj.id !== action.id;
       });
+    case alertConstants.CLEAR_ACTIVE:
+      return state.filter((obj) => {
+        return obj.pending === true;
+      });
     case alertConstants.CLEAR_ALL:
       return [];
+    case alertConstants.PROMOTE_PENDING: {
+      const newState = [];
+      state.forEach((obj) => {
+        const newObj = obj;
+        newObj.pending = false;
+        newState.push(newObj);
+      });
+      return newState;
+    }
     default:
       return state;
   }

--- a/src/variables.js
+++ b/src/variables.js
@@ -29,7 +29,7 @@ export const colors = {
     // turkey
     7: '#ffdc00',
   },
-  danger: '#a73c57',
+  error: '#a73c57',
   success: '#3e7947',
 };
 

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -17,7 +17,8 @@ const App = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   useEffect(() => {
-    dispatch(alertActions.clearAll());
+    dispatch(alertActions.clearActive());
+    dispatch(alertActions.promotePending());
   }, [location.pathname]);
 
   return (

--- a/src/views/CreateGame.jsx
+++ b/src/views/CreateGame.jsx
@@ -38,7 +38,7 @@ class CreateGame extends Component {
     gameService.create(token, { name, description }).then(() => {
       this.setState({ isLoaded: true });
       history.push('/');
-      success({ message: 'Game created!' });
+      success({ message: 'Game created!', category: 'success' });
     });
   }
 
@@ -94,7 +94,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    success: (alert) => dispatch(alertActions.success(alert)),
+    success: (alert) => dispatch(alertActions.add(alert)),
   };
 };
 


### PR DESCRIPTION
- Combine alert actions `success()` and `error()` into `add()` (with `category` parameter which accepts `success` or `error` - rename `type` to `category` in flash messages, as `type` is already used in alerts)
- Add `pending` parameter, which if set causes the flash message to not render (instead it's in a sort of "queue")
- Add `promotePending()` alert action, which disables pending on all alerts (ie they will now render)
- Add `clearActive()` alert action, which removes all non-pending alerts
- Remove `setTimeout()` hack from alert `dispatch`es, and add `pending: true` instead
- Change `clearAll()` to `clearActive()` in `App`, and add `promotePending()` afterwards