### PR TITLE
Wait until variants have loaded before attempting to render games

### DIFF
--- a/src/store/variants.jsx
+++ b/src/store/variants.jsx
@@ -20,11 +20,16 @@ const variantAdapter = createEntityAdapter();
 
 const variantSlice = createSlice({
   name: 'variants',
-  initialState: variantAdapter.getInitialState({ loading: false }),
+  initialState: variantAdapter.getInitialState({
+    loading: false,
+    error: null,
+    loaded: false,
+  }),
   extraReducers: {
     [getVariants.fulfilled]: (state, action) => {
       variantAdapter.setAll(state, action);
       state.loading = false;
+      state.loaded = true;
     },
     [getVariants.pending]: (state) => {
       state.loading = true;

--- a/src/views/BrowseGames.jsx
+++ b/src/views/BrowseGames.jsx
@@ -39,9 +39,11 @@ const BrowseGames = (props) => {
 };
 
 const mapStateToProps = (state, { location }) => {
+  const { loaded: variantsLoaded } = state.entities.variants;
   const { browseGamesLoaded, loading } = state.entities.games;
   let games = null;
-  if (browseGamesLoaded && !loading) games = getDenormalizedGamesList(state);
+  if (browseGamesLoaded && variantsLoaded && !loading)
+    games = getDenormalizedGamesList(state);
   return {
     choices: state.choices,
     games,


### PR DESCRIPTION
I optimised the games view which means that the games return quicker than the variants. This caused an error where the games attempt to load before the variants are in the store. This PR makes the browse games view wait until variants are loaded before attempting to render the games