### PR TITLE
Fix ordering of wrappers to ensure history is available as prop

### DIFF
--- a/src/views/RouterLoggedOut.jsx
+++ b/src/views/RouterLoggedOut.jsx
@@ -93,7 +93,6 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withRouter(RouterLoggedOut));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(RouterLoggedOut)
+);


### PR DESCRIPTION
* Fixes an issue where redirects weren't working in RouterLoggedOut views
  because `history` was not available to `mapDispatchToProps`. This was caused
  by the component wrappers being in the wrong order.
